### PR TITLE
Updating dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,13 +8,13 @@
     "lint": "vue-cli-service lint"
   },
   "dependencies": {
-    "appwrite": "^4.0.4",
+    "appwrite": "^10.1.0",
     "core-js": "^3.6.5",
-    "register-service-worker": "^1.7.1",
-    "vue": "^2.6.11",
-    "vue-router": "^3.2.0",
-    "vuetify": "^2.4.0",
-    "vuex": "^3.4.0"
+    "register-service-worker": "^1.7.2",
+    "vue": "^2.7.13",
+    "vue-router": "^3.6.5",
+    "vuetify": "^2.6.12",
+    "vuex": "^3.6.2"
   },
   "devDependencies": {
     "@vue/cli-plugin-babel": "~4.5.0",
@@ -22,7 +22,7 @@
     "@vue/cli-plugin-pwa": "~4.5.0",
     "@vue/cli-plugin-router": "~4.5.0",
     "@vue/cli-plugin-vuex": "~4.5.0",
-    "@vue/cli-service": "~4.5.0",
+    "@vue/cli-service": "^4.5.19",
     "babel-eslint": "^10.1.0",
     "eslint": "^6.7.2",
     "eslint-plugin-vue": "^6.2.2",


### PR DESCRIPTION
Aging dependencies need updating.

Note: this is using an older verison of webpack and requires Node v16 or older.